### PR TITLE
Replace deprecated class FloatMath by class Math

### DIFF
--- a/android/actionbarsherlock/src/com/actionbarsherlock/internal/nineoldandroids/view/animation/AnimatorProxy.java
+++ b/android/actionbarsherlock/src/com/actionbarsherlock/internal/nineoldandroids/view/animation/AnimatorProxy.java
@@ -147,10 +147,10 @@ public final class AnimatorProxy extends Animation {
         after.union(mBefore);
 
         parent.invalidate(
-                (int) FloatMath.floor(after.left),
-                (int) FloatMath.floor(after.top),
-                (int) FloatMath.ceil(after.right),
-                (int) FloatMath.ceil(after.bottom));
+                (int) Math.floor(after.left),
+                (int) Math.floor(after.top),
+                (int) Math.ceil(after.right),
+                (int) Math.ceil(after.bottom));
     }
 
     private void computeRect(final RectF r, View view) {


### PR DESCRIPTION
The class FloatMath was deprecated in API level 22
and removed in version 23.

Signed-off-by: Stefan Weil <sw@weilnetz.de>