### PR TITLE
updated routes: now exporting assets (for swagger.json)

### DIFF
--- a/server/conf/routes
+++ b/server/conf/routes
@@ -3,36 +3,17 @@
 ->  /    api.Routes
 
 # Not in use.
+# the below tag (NoDocs) hides the documentation
 ### NoDocs ###
 POST        /api/user/auth/admin/migration/run                                  controllers.UserAdminController.migrateToMongoDB()
 
 ###########
 ### RESOURCES:
 ###########
-## WEB APPS:
-# DEVELOPERS:
-#GET         /developers/*file                                                       controllers.Assets.at(path="/public/developers", file)
-#GET         /developers/                                                            controllers.WebAppController.serveDevelopers(file="index.html")
-#GET         /developers                                                             controllers.WebAppController.AddTrailingSlash()
-
-# ARCHITECT:
-#GET         /architect/*file                                                        controllers.Assets.at(path="/public/anyplace_architect", file)
-#GET         /architect/                                                             controllers.WebAppController.serveArchitect(file="index.html")
-#GET         /architect                                                              controllers.WebAppController.AddTrailingSlash()
-
-# VIEWER:
-#GET /viewer/index.html                                                              controllers.WebAppController.serveViewer(file="index.html")
-#GET /viewer/*file                                                                   controllers.MainController.at(path="/public", file)
-#GET /viewer/                                                                        controllers.WebAppController.serveViewer(file="index.html")
-#GET /viewer                                                                         controllers.WebAppController.AddTrailingSlash()
-
 ## OTHER:
-#GET /favicon.ico                                                                    controllers.Assets.at(path="/public/images", file="favicon.png")
 # must match application.conf
 GET /floortiles/zip/*file                                                           controllers.ExternalAssets.at(path="/floor_plans", file)
+
 # maps from /public to /assets
-#GET /assets/*file                                                                   controllers.Assets.at(path="/public", file)
-# root
-#GET /                                                                               controllers.MainController.index()
-# REDIRECT REMAINING TO INDEX
-#GET /*any                                                                           controllers.MainController.indexRedirect(any)
+# needed for publishing online the swagger file (/assets/swagger.json)
+GET /assets/*file                                                                   controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
Swagger json can be found at: {URI}/assets/swagger.json.

also removed previous mappings for /developers, /architect, /viewer, etc.

Anything related to front-end is now on the front-end.
Regarding developers, it's a simple HTML+JS file that is loading the {URI}/assets/swagger.json file.